### PR TITLE
fix: reduce motion on iOS 14 breaks KeyboardAvoidingView

### DIFF
--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -73,7 +73,9 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
 
   _relativeKeyboardHeight(keyboardFrame: KeyboardEventCoordinates): number {
     const frame = this._frame;
-    if (!frame || !keyboardFrame) {
+    // with iOS 14 & Reduce Motion > Prefer Cross-Fade Transitions enabled, the keyboard position
+    // & height is reported differently (0 instead of Y position value matching height of frame)
+    if (!frame || !keyboardFrame || keyboardFrame.screenY === 0) {
       return 0;
     }
 


### PR DESCRIPTION
With iOS 14 & Reduce Motion > Prefer Cross-Fade Transitions enabled, the keyboard position
& height is reported differently (0 instead of Y position value matching height of frame).
See: [facebook#29974 (comment)](https://github.com/facebook/react-native/issues/29974#issuecomment-700804626)

This commit implements the fix mentioned in the link above.